### PR TITLE
Reference the correct library in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     author="Starforge Labs",
     packages=find_packages(),
     install_requires=[
-        "serial"
-        # Add dependencies here. For instance, if the project depends on 'requests' you can add 'requests' to this list
+        "pyserial"
     ],
     classifiers=[
         "Development Status :: Alpha",


### PR DESCRIPTION
[serial](https://pypi.org/project/serial) unfortunately isn't the correct package. It should be [pyserial](https://pypi.org/project/pyserial).